### PR TITLE
Add TLS extension SNI for boost asio based http_client

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -35,4 +35,7 @@ Gery Vessere (gery@vessere.com)
 Cisco Systems
 Gergely Lukacsy (glukacsy)
 
+Ocedo GmbH
+Henning Pfeiffer (megaposer)
+
 thomasschaub

--- a/Release/include/cpprest/http_client.h
+++ b/Release/include/cpprest/http_client.h
@@ -101,6 +101,7 @@ public:
         , m_set_user_nativehandle_options([](native_handle)->void{})
 #if !defined(_WIN32) && !defined(__cplusplus_winrt)
         , m_ssl_context_callback([](boost::asio::ssl::context&)->void{})
+        , m_tlsext_host_name(true)
 #endif
 #if defined(_WIN32) && !defined(__cplusplus_winrt)
         , m_buffer_request(false)
@@ -347,6 +348,25 @@ public:
     {
         return m_ssl_context_callback;
     }
+
+    /// <summary>
+    /// Gets the TLS server name indication (SNI) property.
+    /// </summary>
+    /// <returns>True if TLS server name indication is enabled, false otherwise.</returns>
+    bool tlsext_host_name() const
+    {
+        return m_tlsext_host_name;
+    }
+
+    /// <summary>
+    /// Sets the TLS server name indication (SNI) property.
+    /// </summary>
+    /// <param name="tlsext_host_name">False to disable the TLS (ClientHello) extension for server name indication, true otherwise.</param>
+    /// <remarks>Note: This setting is required in most virtual hosting scenarios.</remarks>
+    void set_tlsext_host_name(bool tlsext_host_name)
+    {
+        m_tlsext_host_name = tlsext_host_name;
+    }
 #endif
 
 private:
@@ -372,6 +392,7 @@ private:
 
 #if !defined(_WIN32) && !defined(__cplusplus_winrt)
     std::function<void(boost::asio::ssl::context&)> m_ssl_context_callback;
+    bool m_tlsext_host_name;
 #endif
 #if defined(_WIN32) && !defined(__cplusplus_winrt)
     bool m_buffer_request;


### PR DESCRIPTION
- adds the TLS server name indication extension during handshake
  (ClientHello)
- enabled by default as most virtual host environments require it
  nowadays
- note: setting the extension could potentially fail (i.e. if TLS would
  be disabled on the stream altogether), but other SSL stream options are
  not "guarded" either
